### PR TITLE
Added support for stretched and reduced images

### DIFF
--- a/src/pixelselect.js
+++ b/src/pixelselect.js
@@ -109,7 +109,8 @@
 			// get rendering object for canvas
 			var ctx			=	canvas.getContext('2d');
 			// draw image on canvas
-			ctx.drawImage(this.image,0,0);
+			ctx.drawImage(this.image,0,0, canvas.width, canvas.height, 0, 0, 
+                    this.element.width, this.element.height);
 			// if debug is activated attach canvas to body
 			if(this.options['debug'] === true) {
 				$(canvas).appendTo('body');


### PR DESCRIPTION
Hey,

I'm working on a little html game for a school project and I've tried using this project for hit detection.
I've come across some weird behavior when trying to detect hit on stretched or reduced images.
For example if you take an image with dimensions of 200 by 200 and set it's height to 100 in it's tag or in the css file, you'll get false hit detections. 
This is due to the fact that the canvas is created by the images full dimensions, yet the data is compared by pixel values on the actual page.
To fix this I've used the drawImage function optional arguments to stretch/reduce the image to the actual value of the element.
While this works for me right now, this isn't a complete solution since if the dimensions are changed in run-time, the canvas will be invalid. 
Perhaps something like this http://marcj.github.io/css-element-queries/ can help, but I'll leave that for another time (aka when it's needed).

So if this something you're interested in, feel free to merge this in :)
